### PR TITLE
set _remove to false in game.Scene.addObject for reusing object

### DIFF
--- a/src/engine/scene.js
+++ b/src/engine/scene.js
@@ -92,6 +92,7 @@ game.Scene = game.Class.extend({
         @param {Object} object
     **/
     addObject: function(object) {
+        if(object._remove) object._remove = false;    
         this.objects.push(object);
     },
 


### PR DESCRIPTION
When remove object from scene and add it again, it's _remove property is still true.
And it will be removed again at next frame.

So set _remove to false when adding object.
