### PR TITLE
Fix for issue #66.

### DIFF
--- a/src/engine/particle.js
+++ b/src/engine/particle.js
@@ -321,7 +321,7 @@ game.Emitter = game.Class.extend({
         particle.life = this.life + this.getVariance(this.lifeVar);
 
         if(!particle.sprite) {
-            particle.sprite = new game.Sprite(particle.position.x, particle.position.y, this.textures.random(), this.spriteSettings);
+            particle.sprite = new game.Sprite(this.textures.random(), particle.position.x, particle.position.y, this.spriteSettings);
         } else {
             particle.sprite.setTexture(this.textures.random());
             particle.sprite.position.x = particle.position.x;


### PR DESCRIPTION
Changed the parameter order to the Sprite constructor when creating a
new sprite for a particle emitter.

Related to
https://github.com/ekelokorpi/panda.js/commit/1847f2f81383f9c1bb408505160eec6dbb549d44

Fix for branching from develop instead of master.
