### PR TITLE
Add onRepeat callback to tween.js

### DIFF
--- a/src/engine/tween.js
+++ b/src/engine/tween.js
@@ -114,6 +114,7 @@ game.Tween = game.Class.extend({
     onStartCallbackFired: false,
     onUpdateCallback: null,
     onCompleteCallback: null,
+    onRepeatCallback: null,
     currentTime: 0,
 
     init: function(object) {
@@ -281,6 +282,15 @@ game.Tween = game.Class.extend({
         this.onCompleteCallback = callback;
         return this;
     },
+    
+    /**
+     * @method onRepeat
+     * @param {Function} callback
+     */
+     onRepeat: function(callback) {
+         this.onRepeatCallback = callback;
+         return this;
+     },
 
     update: function() {
         if(this.paused) return true;
@@ -340,6 +350,9 @@ game.Tween = game.Class.extend({
                 }
                 if(!this.delayRepeat) this.delayTime = 0;
                 this.startTime = this.originalStartTime + this.repeats * (this.duration + this.delayTime);
+                if (this.onRepeatCallback !== null) {
+                    this.onRepeatCallback.call(this.object);
+                }
                 return true;
             } else {
                 this.isPlaying = false;


### PR DESCRIPTION
Adds a callback method to tween.js that fires each time a tween is repeated.  Use case: ball bouncing and a sound needs to be played at each repeat.
