### PR TITLE
Emitter cleans up particles when removed

### DIFF
--- a/src/engine/particle.js
+++ b/src/engine/particle.js
@@ -432,7 +432,6 @@ game.Emitter = game.Class.extend({
         var i;
 
         if (this._remove) {
-            this.active = false;
             while (this.particles.length > 0) {
                 this.removeParticle(this.particles[0]);
             }


### PR DESCRIPTION
If an emitter has _remove set to true, it doesn't remove any particles that are currently visible and these remain on the stage as static sprites. This change causes the emitter to remove all its particles prior to being removed itself.
