### PR TITLE
Loader fires the completion code even if nothing was loaded

### DIFF
--- a/src/engine/loader.js
+++ b/src/engine/loader.js
@@ -157,7 +157,8 @@ game.Loader = game.Class.extend({
         }
 
         if (this.assetQueue.length > 0) this.loader.load();
-        else this.loadAudio();
+        else if (this.soundQueue.length > 0) this.loadAudio();
+        else this.ready();
 
         return this;
     },


### PR DESCRIPTION
I ran into a problem when using the dynamic loading system to load a custom background for each level in a game. This was the only asset the dynamic loader was going to load, but if another level had already loaded the background image in question (in other words two levels shared a background) then the loader simply returned and never called my 'loaded' callback function. I could work around it by checking if the queue of assets to load is 0 prior to calling into the loader, but it feels like a better solution to me for the loader to call the completion code (including any callback that was provided) even if it didn't load anything.
