### PR TITLE
Backspace bugfix

### DIFF
--- a/src/engine/keyboard.js
+++ b/src/engine/keyboard.js
@@ -204,7 +204,8 @@ game.Keyboard = game.Class.extend({
         @method keydown
     **/
     keydown: function(event) {
-        if (!this.keys[event.keyCode]) return; // unkown key
+    	if(event.keyCode==8){event.preventDefault();}
+        if (!this.keys[event.keyCode]) return; // unknown key
         if (this.keysDown[this.keys[event.keyCode]]) return; // key already down
 
         this.keysDown[this.keys[event.keyCode]] = true;


### PR DESCRIPTION
In many browsers Backspace triggers a redirect to the previous page in the browser. As a result, you can't implement the backspace key in your game for the user to correct a spelling mistake.

 This is fixed in this update by adding a preventDefault() in the keyDown function.
